### PR TITLE
Bringing Back the old heat up which saves time!

### DIFF
--- a/macros/toolchanger-macros.cfg
+++ b/macros/toolchanger-macros.cfg
@@ -293,7 +293,9 @@ gcode:
 
   M117 Homing
   G28
-  
+  M117 Cleaning the nozzle
+  CLEAN_NOZZLE TEMP={ TOOL_TEMP - 20 }
+
   M117 Heating up
   M140 S{ params.BED_TEMP }
 

--- a/macros/toolchanger-macros.cfg
+++ b/macros/toolchanger-macros.cfg
@@ -293,14 +293,14 @@ gcode:
 
   M117 Homing
   G28
-  M117 Cleaning the nozzle
-  CLEAN_NOZZLE TEMP={ TOOL_TEMP - 20 }
-
-  M117 Heating up the bed
-  M190 S{ BED_TEMP }
+  
+  M117 Heating up
+  M140 S{ params.BED_TEMP }
 
   M117 Calibrating bed
   M109 S150 ; Heat up nozzle to soften any leftover filament for homing.
+  M190 S{ params.BED_TEMP }
+
   G32 ; Home, gantry tram
   M109 S0 # Stop to heat, the actual printing may happen with a different hotend
 


### PR DESCRIPTION
Nozzle heat up now takes no time as its completed while the bed is being heated.
  
  M117 Heating up
  M140 S{ params.BED_TEMP }

  M117 Calibrating bed
  M109 S150 ; Heat up nozzle to soften any leftover filament for homing.
  M190 S{ params.BED_TEMP }