### PR TITLE
Fix for missing LEDs

### DIFF
--- a/examples/toolchanger-leds.cfg
+++ b/examples/toolchanger-leds.cfg
@@ -144,6 +144,7 @@ gcode:
     {% endfor %}
 
 [gcode_macro _set_toolchanger_leds_by_name]
+variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -158,9 +159,13 @@ gcode:
 
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={color.r} green={color.g} blue={color.b} white={color.w} idx="{idx}" transmit={transmit}
+    {% elif output_warning == 1 %}
+        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"~leds_name~"_led_name"~" is not found"}'
+        SET_GCODE_VARIABLE MACRO=_set_toolchanger_leds_by_name VARIABLE=output_warning VALUE=0
     {% endif %}
 
 [gcode_macro _set_logo_leds]
+variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -176,9 +181,13 @@ gcode:
 
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    {% elif output_warning == 1 %}
+        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"logo_led_name is not found"}'
+        SET_GCODE_VARIABLE MACRO=_set_logo_leds VARIABLE=output_warning VALUE=0
     {% endif %}
 
 [gcode_macro _set_nozzle_leds]
+variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -194,6 +203,9 @@ gcode:
     
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    {% elif output_warning == 1 %}
+        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"nozzle_led_name is not found"}'
+        SET_GCODE_VARIABLE MACRO=_set_nozzle_leds VARIABLE=output_warning VALUE=0
     {% endif %}
 
 [gcode_macro set_logo_leds_off]

--- a/examples/toolchanger-leds.cfg
+++ b/examples/toolchanger-leds.cfg
@@ -156,7 +156,9 @@ gcode:
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"][leds_name + "_idx"] %}
     {% set transmit = params.TRANSMIT|default(1) %}
 
-    _set_toolchanger_leds led={led} red={color.r} green={color.g} blue={color.b} white={color.w} idx="{idx}" transmit={transmit}
+    {% if led is defined %}
+        _set_toolchanger_leds led={led} red={color.r} green={color.g} blue={color.b} white={color.w} idx="{idx}" transmit={transmit}
+    {% endif %}
 
 [gcode_macro _set_logo_leds]
 gcode:
@@ -172,7 +174,9 @@ gcode:
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"].logo_idx %}
     {% set transmit=params.TRANSMIT|default(1) %}
 
-    _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    {% if led is defined %}
+        _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    {% endif %}
 
 [gcode_macro _set_nozzle_leds]
 gcode:
@@ -187,8 +191,10 @@ gcode:
     {% set led = printer["gcode_macro _T" + tn|string + "_vars"].nozzle_led_name %}
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"].nozzle_idx %}
     {% set transmit=params.TRANSMIT|default(1) %}
-
-    _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    
+    {% if led is defined %}
+        _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
+    {% endif %}
 
 [gcode_macro set_logo_leds_off]
 gcode:

--- a/examples/toolchanger-leds.cfg
+++ b/examples/toolchanger-leds.cfg
@@ -98,6 +98,8 @@
 
 
 [gcode_macro _toolchanger_led_vars]
+# enable variable_debug_leds to help troubleshoot LED configuration issues.
+variable_debug_leds: False
 # User settings for the StealthBurner status leds. You can change the status colors and led
 # configurations for the logo and nozzle here.
 variable_colors: {
@@ -144,7 +146,6 @@ gcode:
     {% endfor %}
 
 [gcode_macro _set_toolchanger_leds_by_name]
-variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -155,17 +156,16 @@ gcode:
     {% set color = printer["gcode_macro _toolchanger_led_vars"].colors[leds_name][color_name] %}
     {% set led = printer["gcode_macro _T" + tn|string + "_vars"][leds_name + "_led_name"] %}
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"][leds_name + "_idx"] %}
+    {% set debug_leds = printer["gcode_macro _toolchanger_led_vars"].debug_leds %}
     {% set transmit = params.TRANSMIT|default(1) %}
 
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={color.r} green={color.g} blue={color.b} white={color.w} idx="{idx}" transmit={transmit}
-    {% elif output_warning == 1 %}
+    {% elif debug_leds %}
         RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"~leds_name~"_led_name"~" is not found"}'
-        SET_GCODE_VARIABLE MACRO=_set_toolchanger_leds_by_name VARIABLE=output_warning VALUE=0
     {% endif %}
 
 [gcode_macro _set_logo_leds]
-variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -177,17 +177,16 @@ gcode:
     {% set white = params.WHITE|default(0)|float %}
     {% set led = printer["gcode_macro _T" + tn|string + "_vars"].logo_led_name %}
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"].logo_idx %}
+    {% set debug_leds = printer["gcode_macro _toolchanger_led_vars"].debug_leds %}
     {% set transmit=params.TRANSMIT|default(1) %}
 
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
-    {% elif output_warning == 1 %}
-        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"logo_led_name is not found"}'
-        SET_GCODE_VARIABLE MACRO=_set_logo_leds VARIABLE=output_warning VALUE=0
+    {% elif debug_leds %}
+        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:logo_led_name is not found"}'
     {% endif %}
 
 [gcode_macro _set_nozzle_leds]
-variable_output_warning: 1
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% if tn < 0 %}
@@ -199,13 +198,13 @@ gcode:
     {% set white = params.WHITE|default(0)|float %}
     {% set led = printer["gcode_macro _T" + tn|string + "_vars"].nozzle_led_name %}
     {% set idx = printer["gcode_macro _T" + tn|string + "_vars"].nozzle_idx %}
+    {% set debug_leds = printer["gcode_macro _toolchanger_led_vars"].debug_leds %}
     {% set transmit=params.TRANSMIT|default(1) %}
     
     {% if led is defined %}
         _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
-    {% elif output_warning == 1 %}
-        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:"nozzle_led_name is not found"}'
-        SET_GCODE_VARIABLE MACRO=_set_nozzle_leds VARIABLE=output_warning VALUE=0
+    {% elif debug_leds %}
+        RESPOND type=error MSG='{"LED "~"[gcode_macro _T"~tn|string~"_vars]:nozzle_led_name is not found"}'
     {% endif %}
 
 [gcode_macro set_logo_leds_off]

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -6,15 +6,19 @@
 #
 # Contribution 2024 by Justin F. Hallett <thesin@southofheaven.org>
 import logging
-from . import probe
+from .probe import PrinterProbe, ProbeSessionHelper, ProbeEndstopWrapper, ProbeOffsetsHelper, calc_probe_z_average
 
-class ToolProbe:
+class ToolProbe(PrinterProbe):
     def __init__(self, config):
         self.tool = config.getint('tool')
-        self.printer = config.get_printer()
         self.name = config.get_name()
-        self.mcu_probe = probe.ProbeEndstopWrapper(config)
-        self.probe_offsets = probe.ProbeOffsetsHelper(config)
+        
+        self.printer = config.get_printer()
+        self.mcu_probe = ProbeEndstopWrapper(config)
+        # Handled in tool_probe_endstop
+        #self.cmd_helper = ProbeCommandHelper(config, self,
+        #                                     self.mcu_probe.query_endstop)
+        self.probe_offsets = ProbeOffsetsHelper(config)
         self.probe_session = ProbeSessionHelper(config, self.mcu_probe)
 
         # Crash detection stuff
@@ -24,29 +28,21 @@ class ToolProbe:
         ppins.allow_multi_use_pin(pin.replace('^', '').replace('!', ''))
         buttons.register_buttons([pin], self._button_handler)
 
-        #Register with the endstop
+        # Register with the endstop
         self.endstop = self.printer.load_object(config, "tool_probe_endstop")
         self.endstop.add_probe(config, self)
-
     def _button_handler(self, eventtime, is_triggered):
         self.endstop.note_probe_triggered(self, eventtime, is_triggered)
 
-    def get_probe_params(self, gcmd=None):
-        return self.probe_session.get_probe_params(gcmd)
-    def get_offsets(self):
-        return self.probe_offsets.get_offsets()
-    def start_probe_session(self, gcmd):
-        return self.probe_session.start_probe_session(gcmd)
 
 # Helper to track multiple probe attempts in a single command
-class ProbeSessionHelper:
+class ProbeSessionHelper(ProbeSessionHelper):
     def __init__(self, config, mcu_probe):
+        self.drop_first_result = config.getboolean("drop_first_result", False)
         self.printer = config.get_printer()
         self.mcu_probe = mcu_probe
         gcode = self.printer.lookup_object('gcode')
         self.dummy_gcode_cmd = gcode.create_gcode_command("", "", {})
-        # Fix for Danger Klipper compatability
-        self.drop_first_result = config.getboolean("drop_first_result", False)
         # Infer Z position to move to during a probe
         if config.has_section('stepper_z'):
             zconfig = config.getsection('stepper_z')
@@ -56,6 +52,8 @@ class ProbeSessionHelper:
             pconfig = config.getsection('printer')
             self.z_position = pconfig.getfloat('minimum_z_position', 0.,
                                                note_valid=False)
+        # Handled in tool_probe_endstop
+        # self.homing_helper = HomingViaProbeHelper(config, mcu_probe)
         # Configurable probing speeds
         self.speed = config.getfloat('speed', 5.0, above=0.)
         self.lift_speed = config.getfloat('lift_speed', self.speed, above=0.)
@@ -63,7 +61,7 @@ class ProbeSessionHelper:
         self.sample_count = config.getint('samples', 1, minval=1)
         self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
                                                    above=0.)
-        atypes = {'median': 'median', 'average': 'average'}
+        atypes = ['median', 'average']
         self.samples_result = config.getchoice('samples_result', atypes,
                                                'average')
         self.samples_tolerance = config.getfloat('samples_tolerance', 0.100,
@@ -76,69 +74,6 @@ class ProbeSessionHelper:
         # Register event handlers
         self.printer.register_event_handler("gcode:command_error",
                                             self._handle_command_error)
-    def _handle_command_error(self):
-        if self.multi_probe_pending:
-            try:
-                self.end_probe_session()
-            except:
-                logging.exception("Multi-probe end")
-    def _probe_state_error(self):
-        raise self.printer.command_error(
-            "Internal probe error - start/end probe session mismatch")
-    def start_probe_session(self, gcmd):
-        if self.multi_probe_pending:
-            self._probe_state_error()
-        self.mcu_probe.multi_probe_begin()
-        self.multi_probe_pending = True
-        self.results = []
-        return self
-    def end_probe_session(self):
-        if not self.multi_probe_pending:
-            self._probe_state_error()
-        self.results = []
-        self.multi_probe_pending = False
-        self.mcu_probe.multi_probe_end()
-    def get_probe_params(self, gcmd=None):
-        if gcmd is None:
-            gcmd = self.dummy_gcode_cmd
-        probe_speed = gcmd.get_float("PROBE_SPEED", self.speed, above=0.)
-        lift_speed = gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.)
-        samples = gcmd.get_int("SAMPLES", self.sample_count, minval=1)
-        sample_retract_dist = gcmd.get_float("SAMPLE_RETRACT_DIST",
-                                             self.sample_retract_dist, above=0.)
-        samples_tolerance = gcmd.get_float("SAMPLES_TOLERANCE",
-                                           self.samples_tolerance, minval=0.)
-        samples_retries = gcmd.get_int("SAMPLES_TOLERANCE_RETRIES",
-                                       self.samples_retries, minval=0)
-        samples_result = gcmd.get("SAMPLES_RESULT", self.samples_result)
-        return {'probe_speed': probe_speed,
-                'lift_speed': lift_speed,
-                'samples': samples,
-                'sample_retract_dist': sample_retract_dist,
-                'samples_tolerance': samples_tolerance,
-                'samples_tolerance_retries': samples_retries,
-                'samples_result': samples_result}
-    def _probe(self, speed):
-        toolhead = self.printer.lookup_object('toolhead')
-        curtime = self.printer.get_reactor().monotonic()
-        if 'z' not in toolhead.get_status(curtime)['homed_axes']:
-            raise self.printer.command_error("Must home before probe")
-        pos = toolhead.get_position()
-        pos[2] = self.z_position
-        try:
-            epos = self.mcu_probe.probing_move(pos, speed)
-        except self.printer.command_error as e:
-            reason = str(e)
-            if "Timeout during endstop homing" in reason:
-                reason += probe.HINT_TIMEOUT
-            raise self.printer.command_error(reason)
-        # Allow axis_twist_compensation to update results
-        self.printer.send_event("probe:update_results", epos)
-        # Report results
-        gcode = self.printer.lookup_object('gcode')
-        gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
-                           % (epos[0], epos[1], epos[2]))
-        return epos[:3]
     def run_probe(self, gcmd, check_drop=True):
         if not self.multi_probe_pending:
             self._probe_state_error()
@@ -171,12 +106,9 @@ class ProbeSessionHelper:
                     probexy + [pos[2] + params['sample_retract_dist']],
                     params['lift_speed'])
         # Calculate result
-        epos = probe.calc_probe_z_average(positions, params['samples_result'])
+        epos = calc_probe_z_average(positions, params['samples_result'])
         self.results.append(epos)
-    def pull_probed_results(self):
-        res = self.results
-        self.results = []
-        return res
+
 
 def load_config_prefix(config):
     return ToolProbe(config)

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -139,7 +139,7 @@ class ProbeSessionHelper:
         gcode.respond_info("probe at %.3f,%.3f is z=%.6f"
                            % (epos[0], epos[1], epos[2]))
         return epos[:3]
-    def run_probe(self, gcmd):
+    def run_probe(self, gcmd, check_drop=True):
         if not self.multi_probe_pending:
             self._probe_state_error()
         params = self.get_probe_params(gcmd)

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -152,7 +152,7 @@ class ProbeSessionHelper:
         while len(positions) < sample_count:
             # Probe position
             pos = self._probe(params['probe_speed'])
-            if self.drop_first_result and first_probe:
+            if check_drop and self.drop_first_result and first_probe:
                 gcmd.respond_info("dropping probe result, settling")
             else:
                 positions.append(pos)

--- a/klipper/extras/tool_probe.py
+++ b/klipper/extras/tool_probe.py
@@ -152,7 +152,7 @@ class ProbeSessionHelper:
         while len(positions) < sample_count:
             # Probe position
             pos = self._probe(params['probe_speed'])
-            if check_drop and self.drop_first_result and first_probe:
+            if self.drop_first_result and first_probe:
                 gcmd.respond_info("dropping probe result, settling")
             else:
                 positions.append(pos)

--- a/klipper/extras/tool_probe_endstop.py
+++ b/klipper/extras/tool_probe_endstop.py
@@ -3,7 +3,10 @@
 # Copyright (C) 2023 Viesturs Zarins <viesturz@gmail.com>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Contribution 2024 by Justin F. Hallett <thesin@southofheaven.org>
 from . import probe
+from .probe import ProbeCommandHelper
 
 # Virtual endstop, using a tool attached Z probe in a toolchanger setup.
 # Tool endstop change may be done either via SET_ACTIVE_TOOL_PROBE TOOL=99
@@ -22,7 +25,7 @@ class ToolProbeEndstop:
         self.crash_lasttime = 0.
         self.mcu_probe = EndstopRouter(self.printer)
         self.homing_helper = probe.HomingViaProbeHelper(config, self.mcu_probe)
-        self.cmd_helper = probe.ProbeCommandHelper(config, self, self.mcu_probe.query_endstop)
+        self.cmd_helper = TCProbeCommandHelper(config, self, self.mcu_probe.query_endstop)
 
         # Emulate the probe object, since others rely on this.
         if self.printer.lookup_object('probe', default=None):
@@ -246,6 +249,61 @@ class EndstopRouter:
             # Report 0 and fix up in the homing sequence
             return 0.0
         return self.active_mcu.get_position_endstop()
+
+
+class TCProbeCommandHelper(ProbeCommandHelper):
+    def __init__(self, config, probe, query_endstop=None):
+        ProbeCommandHelper.__init__(self, config, probe, query_endstop)
+    def cmd_PROBE_ACCURACY(self, gcmd):
+        params = self.probe.get_probe_params(gcmd)
+        sample_count = gcmd.get_int("SAMPLES", 10, minval=1)
+        toolhead = self.printer.lookup_object('toolhead')
+        pos = toolhead.get_position()
+        gcmd.respond_info("PROBE_ACCURACY at X:%.3f Y:%.3f Z:%.3f"
+                          " (samples=%d retract=%.3f"
+                          " speed=%.1f lift_speed=%.1f)\n"
+                          % (pos[0], pos[1], pos[2],
+                             sample_count, params['sample_retract_dist'],
+                             params['probe_speed'], params['lift_speed']))
+        # Create dummy gcmd with SAMPLES=1
+        fo_params = dict(gcmd.get_command_parameters())
+        fo_params['SAMPLES'] = '1'
+        gcode = self.printer.lookup_object('gcode')
+        fo_gcmd = gcode.create_gcode_command("", "", fo_params)
+        # Probe bed sample_count times
+        probe_session = self.probe.start_probe_session(fo_gcmd)
+        probe_num = 0
+        drop = probe_session.drop_first_result
+        while probe_num < sample_count:
+            # Probe position
+            probe_session.run_probe(fo_gcmd, drop)
+            if drop:
+                drop = False
+            else:
+                probe_num += 1
+            # Retract
+            pos = toolhead.get_position()
+            liftpos = [None, None, pos[2] + params['sample_retract_dist']]
+            self._move(liftpos, params['lift_speed'])
+        positions = probe_session.pull_probed_results()
+        probe_session.end_probe_session()
+        # Calculate maximum, minimum and average values
+        max_value = max([p[2] for p in positions])
+        min_value = min([p[2] for p in positions])
+        range_value = max_value - min_value
+        avg_value = probe.calc_probe_z_average(positions, 'average')[2]
+        median = probe.calc_probe_z_average(positions, 'median')[2]
+        # calculate the standard deviation
+        deviation_sum = 0
+        for i in range(len(positions)):
+            deviation_sum += pow(positions[i][2] - avg_value, 2.)
+        sigma = (deviation_sum / len(positions)) ** 0.5
+        # Show information
+        gcmd.respond_info(
+            "probe accuracy results: maximum %.6f, minimum %.6f, range %.6f, "
+            "average %.6f, median %.6f, standard deviation %.6f" % (
+            max_value, min_value, range_value, avg_value, median, sigma))
+
 
 def load_config(config):
     return ToolProbeEndstop(config)

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -191,6 +191,7 @@ class ToolsCalibrate:
         endstop_states = [probe.query_endstop(print_time) for probe in self.probe_multi_axis.mcu_probe] # Check the state of each axis probe (x, y, z)
         self.calibration_probe_inactive = any(endstop_states)
         gcmd.respond_info("Calibration Probe: %s" % (["open", "TRIGGERED"][any(endstop_states)]))
+        return self.calibration_probe_inactive
 
 class PrinterProbeMultiAxis:
     def __init__(self, config, mcu_probe_x, mcu_probe_y, mcu_probe_z):

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -128,7 +128,8 @@ class ToolsCalibrate:
         location = self.locate_sensor(gcmd)
         self.last_result = [location[i] - self.sensor_location[i] for i in
                             range(3)]
-        self.gcode.respond_info("Tool offset is %.6f,%.6f,%.6f"
+
+        self.gcode.respond_info("Paste into your config file for tool:\n\ngcode_x_offset: %.6f\ngcode_y_offset: %.6f\ngcode_z_offset: %.6f\n"
                                 % (self.last_result[0], self.last_result[1],
                                    self.last_result[2]))
 

--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -213,7 +213,7 @@ class PrinterProbeMultiAxis:
         self.sample_count = config.getint('samples', 1, minval=1)
         self.sample_retract_dist = config.getfloat('sample_retract_dist', 2.,
                                                    above=0.)
-        atypes = {'median': 'median', 'average': 'average'}
+        atypes = ['median', 'average']
         self.samples_result = config.getchoice('samples_result', atypes,
                                                'average')
         self.samples_tolerance = config.getfloat('samples_tolerance', 0.100,

--- a/macros/toolchanger-macros.cfg
+++ b/macros/toolchanger-macros.cfg
@@ -284,6 +284,7 @@ gcode:
 gcode:
   {% set TOOL_TEMP = params.TOOL_TEMP|default(150)|float %}
   {% set BED_TEMP = params.BED_TEMP|default(0)|float %}
+  {% set DONTWAITFORBED = params.DONTWAITFORBED|default(0)|int %}
   M117 Initializing...
   INITIALIZE_TOOLCHANGER
   STOP_TOOL_PROBE_CRASH_DETECTION
@@ -296,13 +297,17 @@ gcode:
   M117 Cleaning the nozzle
   CLEAN_NOZZLE TEMP={ TOOL_TEMP - 20 }
 
-  M117 Heating up the bed
+  M117 Heating up
+  {% if DONTWAITFORBED %}
+    M140 S{ BED_TEMP }
+    M104 S150
+  {% endif %}
   M190 S{ BED_TEMP }
 
   M117 Calibrating bed
   M109 S150 ; Heat up nozzle to soften any leftover filament for homing.
   G32 ; Home, gantry tram
-  M109 S0 # Stop to heat, the actual printing may happen with a different hotend
+  M109 S0 ; Stop to heat, the actual printing may happen with a different hotend
 
   {% if printer.toolchanger.tools_preheat %}
     # Preheat all the hotends in use

--- a/macros/toolchanger-macros.cfg
+++ b/macros/toolchanger-macros.cfg
@@ -28,7 +28,7 @@ gcode:
 [gcode_macro _TAP_PROBE_ACTIVATE]
 description: Ensure safe temp for bed probing
 gcode:
-  {% set max_temp = params.TEMP|default(150)|int %}
+  {% set max_temp = params.TEMP|default(150)|float %}
   {% set actual_temp = printer[params.HEATER].temperature %}
   {% set target_temp = printer[params.HEATER].target %}
   {% if target_temp > max_temp %}
@@ -154,7 +154,7 @@ gcode:
   # Wait for temp before actually picking up the tool, while the nozzle is resting on it's pad.
     
   {% if tool.extruder %}
-    M109 T{tool.tool_number} S{printer[tool.extruder].target|int}
+    M109 T{tool.tool_number} S{printer[tool.extruder].target|float}
   {% endif %}
   # Run the path in reverse
   {% for pos in path|reverse %}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,9 +236,8 @@ if [ $doinstall -gt 0 ]; then
         restart_klipper
     fi
 
-    printf "======================================\n"
-    echo "- If you are upgrading maybe sure to -"
-    echo "- you check for changes in the user  -"
-    echo "- config files                       -"
-    printf "======================================\n\n"
+    printf "=============================================\n"
+    echo "- If you are upgrading make sure to           -"
+    echo "- check for changes in the user config files  -"
+    printf "=============================================\n\n"
 fi

--- a/tool_probe.md
+++ b/tool_probe.md
@@ -19,8 +19,9 @@ crash_gcode:
 [tool_probe T1]
 pin: !et1:PB6
 tool: 1
-z_offset:  -0.75
+z_offset: -0.75
 speed: 5.0
+drop_first_result: True
 samples: 3
 samples_result: median
 sample_retract_dist: 2.0

--- a/usermods/VIN-y/config_switch.md
+++ b/usermods/VIN-y/config_switch.md
@@ -1,0 +1,52 @@
+# Config Switch
+
+This extension provide the means to quickly convert the config from a tool-changer to a traditional single tool-head printer.
+
+## Added Console Command
+
+| Command              | Description                                |
+| -------------------- | ------------------------------------------ |
+| `SAVE_CONFIG_MODE`   | Save session variables in **printer.cfg**. |
+| `TOGGLE_CONFIG_MODE` | Detect and toggle current session config.  |
+
+## Details
+
+#### SAVE_CONFIG_MODE
+
+1. The recording point is marked with `#;<` and can be closed with `#;>`.
+
+2. The command relies on a macro variable, `variable_dock:`, in **printer.cfg** to determine where to save the config to. Therefore, it requires the following `[gcode_macro _home]` macro in **printer.cfg**, within the session that will be toggle in and out:
+   
+   ```
+   [gcode_macro _home]
+   variable_xh: 175.0
+   variable_yh: 235.0
+   variable_zh: 10.0
+   variable_dock: True
+   gcode:
+   ```
+   
+   This variable `variable_dock:` can be either `True` for `False`.
+
+3. The session variables will be safe to `config/config_wt_dock.cfg` or `config/config_no_dock.cfg`
+
+4. It is recommended that you put all of your session variables at the bottom of **printer.cfg**, just before the section for `SAVE_CONFIG`.
+
+#### TOGGLE_CONFIG_MODE
+
+1. Toggle the session variables between that are saved in `config/config_wt_dock.cfg` and `config/config_no_dock.cfg`, if they are available.
+
+2. If either `config/config_wt_dock.cfg` and `config/config_no_dock.cfg` are not yet available. Please build that config (in **printer.cfg**), with the right `variable_dock:` value,  then use `SAVE_CONFIG_MODE` to create the save file.
+
+3. The command needs to be follow up with `FIRMWARE_RESTART` for the printer to implement the new settings. To make it easier, it is suggested that you have the following macro for your printer:
+   
+   ```
+   [gcode_macro PRINTER_CONFIG_TOGGLE]
+   gcode:
+       M400
+       SAVE_CONFIG_MODE
+       M400
+       TOGGLE_CONFIG_MODE
+       M400
+       FIRMWARE_RESTART
+   ```

--- a/usermods/VIN-y/config_switch.py
+++ b/usermods/VIN-y/config_switch.py
@@ -1,0 +1,134 @@
+import os
+import logging
+
+class ConfigSwitch:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.gcode = self.printer.lookup_object('gcode')
+        ## Register Commands
+        self.gcode.register_command('SAVE_CONFIG_MODE',
+                                    self.cmd_SAVE_CONFIG_MODE,
+                                    desc=self.cmd_SAVE_CONFIG_MODE_help)
+        self.gcode.register_command('TOGGLE_CONFIG_MODE',
+                                    self.cmd_TOGGLE_CONFIG_MODE,
+                                    desc=self.cmd_TOGGLE_CONFIG_MODE_help)
+
+
+    cmd_SAVE_CONFIG_MODE_help = "Save session variables, marked in printer.cfg"
+    def cmd_SAVE_CONFIG_MODE(self, gcmd):
+        ## Variables
+        home_dir = os.path.expanduser("~")
+        destination = ""
+        record = False
+
+        printer_config = os.path.join(home_dir, "printer_data/config/printer.cfg")
+        config_dir = os.path.join(home_dir, "printer_data/config/config")
+        config_wt_dock = os.path.join(config_dir, "config_wt_dock.cfg")
+        config_no_dock = os.path.join(config_dir, "config_no_dock.cfg")
+
+        ## Make the config folder, if it is not already there
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir, exist_ok=True)
+        
+        ## Decide where it should be saved
+        with open(printer_config) as file:
+            for line in file:
+                ## Set destination file
+                if "variable_dock:" in line.strip():
+                    if "True" in line.strip():
+                        destination = config_wt_dock
+                    elif "False" in line.strip():
+                        destination = config_no_dock
+                    else:
+                        raise gcmd.error("[variable_dock: ] must be 'True' or 'False'")
+        
+        ## Save session variables
+        with open(printer_config) as file:
+            if destination != "":
+                with open(destination, 'w'):
+                    pass
+                for line in file:
+                    ## Record point begin / end
+                    if "#;<" in line.strip():
+                        record = True
+                    if "#;>" in line.strip():
+                        record = False
+                    
+                    ## Start / Stop record
+                    if record is True:
+                        with open(destination, 'a') as savefile:
+                            savefile.write(line)
+                
+                if "config_wt_dock" in destination:
+                    self.gcode.respond_info("Session variables saved to config/config_wt_dock.cfg")
+                elif "config_no_dock" in destination:
+                    self.gcode.respond_info("Session variables saved to config/config_no_dock.cfg")
+
+
+    cmd_TOGGLE_CONFIG_MODE_help = "Toggle saved session variable in printer.cfg"
+    def cmd_TOGGLE_CONFIG_MODE(self, gcmd):
+        ## Variables
+        home_dir = os.path.expanduser("~")
+        source = ""
+        record = True
+
+        printer_config = os.path.join(home_dir, "printer_data/config/printer.cfg")
+        config_dir = os.path.join(home_dir, "printer_data/config/config")
+        config_wt_dock = os.path.join(config_dir, "config_wt_dock.cfg")
+        config_no_dock = os.path.join(config_dir, "config_no_dock.cfg")
+        config_temp = os.path.join(config_dir, "printer.temp")
+
+        ## Detect and toggle current config
+        with open(printer_config) as file:
+            for line in file:
+                if "variable_dock:" in line.strip():
+                    if "True" in line.strip():
+                        source = config_no_dock
+                    elif "False" in line.strip():
+                        source = config_wt_dock
+                    else:
+                        raise gcmd.error("[variable_dock: ] must be 'True' or 'False'")
+        
+        ## Compile new printer.cfg in printer.temp
+        if source != "":
+            if os.path.exists(source):
+                self.gcode.respond_info("Toggle current session variables to:\n" + source)
+                with open(source, 'r') as session_variable_source:
+                    source_content = session_variable_source.read()
+
+                with open(printer_config) as file:
+                    self.gcode.respond_info("Compile config/printer.temp ...")
+                    with open(config_temp, 'w'):
+                                pass
+                    
+                    for line in file:
+                        ## Record point begin / end
+                        if "#;<" in line.strip():
+                            record = False
+                        if "#;>" in line.strip():
+                            record = True
+
+                        ## Start / Stop record
+                        if record is True:
+                            with open(config_temp, 'a') as tempfile:
+                                tempfile.write(line)
+                    
+                with open(config_temp, 'a') as tempfile:
+                    tempfile.write(source_content)
+
+                with open(config_temp, 'r') as tempfile:
+                    temp_config = tempfile.read()
+                
+                with open(printer_config, 'w') as configfile:
+                    self.gcode.respond_info("Update printer.cfg ...")
+                    configfile.write(temp_config)
+                
+                if os.path.exists(config_temp):
+                    self.gcode.respond_info("Remove config/printer.temp ...")
+                    os.remove(config_temp)
+            else:
+                raise gcmd.error("Missing file:\n" + source)
+
+
+def load_config(config):
+    return ConfigSwitch(config)


### PR DESCRIPTION
Found an issue where if you were missing a category of LEDs (Nozzle or Logo) an error would be thrown when attempting to set those LEDs.  This was not allowing tool changes to happen. 

Added some protection around the setting those LEDs when the `nozzle_led_name`, `logo_led_name`, or `_led_name is not defined in the tool vars. 

I only have a single logo LED and no nozzle LEDs per tool. It seems this scenario can happen if you have one set of LEDs but not the other. 