### PR TITLE
Adding Deadband to M109 when using LEDs

### DIFF
--- a/examples/toolchanger-extra-macros.cfg
+++ b/examples/toolchanger-extra-macros.cfg
@@ -131,22 +131,43 @@ gcode:
 [gcode_macro M109]
 rename_existing: M109.9999
 description: [T<index>] [S<temperature>] [D<Deadband>]
+  Set tool temperature and wait with deadband option.
+  T= Tool number [optional]. If this parameter is not provided, the current tool is used.
+  S= Target temperature
+  D= Dead-band, allows the temperature variance +/- the deadband
+gcode:
+  {% if params.T is defined %}
+    {% set newparameters = " T="~params.T %}
+  {% endif %}
+
+  {% if params.S is defined %}
+    {% set newparameters = newparameters~" S="~params.S %}
+  {% endif %}
+
+  {% if params.D is defined %}
+    {% set newparameters = newparameters~" D="~params.D %}
+  {% endif %}
+
+  SET_TEMPERATURE_WITH_DEADBAND {newparameters}
+
+
+[gcode_macro SET_TEMPERATURE_WITH_DEADBAND]
+description: [T<index>] [S<temperature>] [D<Deadband>]
   Set tool temperature and wait.
   T= Tool number [optional]. If this parameter is not provided, the current tool is used.
   S= Target temperature
   D= Dead-band, allows the temperature variance +/- the deadband
 variable_default_deadband: 1.0
 gcode:
-    {% set s = params.S|float %}
-    {% set deadband = default_deadband|float %}
-    {% if params.D is defined %}
-        {% set deadband = params.D|float %}
-    {% endif %}
+    {% set s = params.S|default(0)|int %}
     {% set tn = params.T|default(printer.tool_probe_endstop.active_tool_number)|int %}
+    {% set d = params.D|default(default_deadband)|float %}
+    
     {% set tool = printer.toolchanger.tool_names[tn]|default('') %}
     {% set extruder = printer[tool].extruder %}
 
     SET_HEATER_TEMPERATURE HEATER={extruder} TARGET={s}
     {% if s > 0 %}
-        TEMPERATURE_WAIT SENSOR={extruder} MINIMUM={s-(deadband/2)} MAXIMUM={s+(deadband/2)}   ; Wait for hotend temp (within D degrees)
+        RESPOND type=echo MSG='{"Waiting For Extruder with Deadband: "~d}'
+        TEMPERATURE_WAIT SENSOR={extruder} MINIMUM={s-(d/2)} MAXIMUM={s+(d/2)}   ; Wait for hotend temp (within D degrees)
     {% endif %}

--- a/examples/toolchanger-leds.cfg
+++ b/examples/toolchanger-leds.cfg
@@ -281,7 +281,11 @@ gcode:
       STATUS_HEATING {newparameters}
     {% endif %}
   {% endif %}
-  M109.99 {rawparams}
+
+  {% if params.S is defined %}
+    {% set newparameters = newparameters~" S="~params.S %}
+  {% endif %}
+  SET_TEMPERATURE_WITH_DEADBAND {newparameters}
   {% if newparameters is defined %}
     STATUS_READY {newparameters}
   {% endif %}


### PR DESCRIPTION
Issue: M109 in the toolchanger-leds.cfg does not support a temperature deadband.   So if you want LED control you lose the ability to have a temperature deadband for M109. 

Solution: Added a new macro `SET_TEMPERATURE_WITH_DEADBAND` which allows setting a user customizable dead band for temp.  Then utilized this method in the 2 M109 overrides.  