### PR TITLE
capitalize led status macros

### DIFF
--- a/examples/toolchanger-leds.cfg
+++ b/examples/toolchanger-leds.cfg
@@ -190,79 +190,79 @@ gcode:
 
     _set_toolchanger_leds led={led} red={red} green={green} blue={blue} white={white} idx="{idx}" transmit={transmit}
 
-[gcode_macro set_logo_leds_off]
+[gcode_macro SET_LOGO_LEDS_OFF]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% set transmit=params.TRANSMIT|default(1) %}
     _set_logo_leds T={tn} red=0 blue=0 green=0 white=0 transmit={transmit}
 
-[gcode_macro set_nozzle_leds_on]
+[gcode_macro SET_NOZZLE_LEDS_ON]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% set transmit=params.TRANSMIT|default(1) %}
     _set_toolchanger_leds_by_name T={tn} leds="nozzle" color="on" transmit={transmit}
 
-[gcode_macro set_nozzle_leds_off]
+[gcode_macro SET_NOZZLE_LEDS_OFF]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     {% set transmit=params.TRANSMIT|default(1) %}
     _set_toolchanger_leds_by_name T={tn} leds="nozzle" color="off" transmit={transmit}
 
-[gcode_macro status_off]
+[gcode_macro STATUS_OFF]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     set_logo_leds_off T={tn} transmit=0
     set_nozzle_leds_off T={tn}
 
-[gcode_macro status_ready]
+[gcode_macro STATUS_READY]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="standby" transmit=0
     _set_toolchanger_leds_by_name T={tn} leds="nozzle" color="standby" transmit=1
 
-[gcode_macro status_busy]
+[gcode_macro STATUS_BUSY]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="busy" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_heating]
+[gcode_macro STATUS_HEATING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="heating" transmit=0
     _set_toolchanger_leds_by_name T={tn} leds="nozzle" color="heating" transmit=1
 
-[gcode_macro status_leveling]
+[gcode_macro STATUS_LEVELING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="leveling" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_homing]
+[gcode_macro STATUS_HOMING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="homing" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_cleaning]
+[gcode_macro STATUS_CLEANING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="cleaning" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_meshing]
+[gcode_macro STATUS_MESHING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="meshing" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_calibrating_z]
+[gcode_macro STATUS_CALIBRATING_Z]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="calibrating_z" transmit=0
     set_nozzle_leds_on T={tn}
 
-[gcode_macro status_printing]
+[gcode_macro STATUS_PRINTING]
 gcode:
     {% set tn = params.T|default(printer.toolchanger.tool_number)|int %}
     _set_toolchanger_leds_by_name T={tn} leds="logo" color="printing" transmit=0


### PR DESCRIPTION
checks like `{% if printer["gcode_macro STATUS_CLEANING"] is defined %}` are case sensitive (and currently do not work), so i've changed led (status) macros to uppercase (like most other macros)