### PR TITLE
prime lines without preheating

### DIFF
--- a/examples/toolchanger-extra-macros.cfg
+++ b/examples/toolchanger-extra-macros.cfg
@@ -227,7 +227,7 @@ gcode:
       {% set bulbasaur = print_tools.insert(0, printer.toolchanger.tool_number) %}
     {% endif %}
 
-    {% else %}
+  {% else %}
       {% set initial_tool = None %}
   {% endif %}
   
@@ -291,7 +291,7 @@ gcode:
       {% endif %}
     {% endif %}
 
-  G90
+    G90
   {% endfor %}
 
   RESTORE_GCODE_STATE NAME=PRIME_LINE_STATE

--- a/examples/toolchanger-extra-macros.cfg
+++ b/examples/toolchanger-extra-macros.cfg
@@ -174,8 +174,9 @@ gcode:
 
 
 [gcode_macro PRIME_LINES]
-description: Prime all active tools before printing.
-  INITIAL_TOOL= Tool number, optional.
+description: Prime tools before printing.
+  Tx_TEMP= Temperature per tool to prime
+  TOOL= Initial tool number, optional.
 variable_tools_per_x:          6      # Number of tools primed in a single row
 variable_lines_per_tool:       4      # Number of prime lines per tool
 variable_line_step_y:          2      # Distance between lines in Y axis
@@ -205,15 +206,16 @@ gcode:
   # Figure out the required tools by which tools are preheating
   {% for tn in printer.toolchanger.tool_numbers %}
     {% set extruder_id = "extruder" + tn|string if tn > 0 else "extruder" %}
+    {% set tooltemp_param = "T" ~ tn|string ~ "_TEMP" %}
 
-    {% if printer[extruder_id].target >= printer.configfile.settings[extruder_id].min_extrude_temp %}
+    {% if tooltemp_param in params and params[tooltemp_param]|int >= printer.configfile.settings[extruder_id].min_extrude_temp %}
       {% set gengar = print_tools.append(tn) %}
     {% endif %}
   {% endfor %}
 
   # Make sure the initial print tool is the last to prime
-  {% if params.INITIAL_TOOL is defined %}
-    {% set initial_tool = params.INITIAL_TOOL|int %}
+  {% if params.TOOL is defined %}
+    {% set initial_tool = params.TOOL|int %}
 
     {% if print_tools|length > 1 %}
       {% set snorlax   = print_tools.pop(print_tools.index(initial_tool)) %}
@@ -234,6 +236,7 @@ gcode:
     T{tn}
 
     {% set extruder_id = "extruder" + tn|string if tn > 0 else "extruder" %}
+    {% set tooltemp_param = "T" ~ tn|string ~ "_TEMP" %}
     {% set t_idx = print_tools.index(tn) %}
     {% set y_idx = (t_idx/tools_per_x)|int %}
     {% set x_tool_list = print_tools[y_idx*tools_per_x:] %}
@@ -246,7 +249,7 @@ gcode:
     G0 Z{z_prime_pos} F{move_speed}
 
     # Wait for temp
-    M109 S{printer[extruder_id].target} T{tn}
+    M109 S{params[tooltemp_param]} T{tn}
 
     # Prime Tool
     M117 Priming T{tn}
@@ -280,16 +283,15 @@ gcode:
     G0 Z{z_move_pos}
 
     # Reduce temp for tools that are not required yet
-    {% if params.INITIAL_TOOL is defined %}
+    {% if params.TOOL is defined %}
       {% if initial_tool in print_tools %}
         {% if tn != initial_tool %}
-          M104 S{printer[extruder_id].target-temp_drop} T{tn}
+          M104 S{params[tooltemp_param]|int - temp_drop} T{tn}
         {% endif %}
       {% endif %}
     {% endif %}
 
   G90
-
   {% endfor %}
 
   RESTORE_GCODE_STATE NAME=PRIME_LINE_STATE


### PR DESCRIPTION
i'm not using preheating of the tools, but want to use prime-lines. Currently the macro depends on the tools being preheated.

The change accepts the params already used in PRINT_START to be passed to make the PRIME_LINES macro so it can be used without preheating.

In PRINT_START (and related macros) it can be now called with the rawparams: `PRIME_LINES {rawparams}`