### PR TITLE
uncomment line adding probe compensation

### DIFF
--- a/macros/toolchanger-homing.cfg
+++ b/macros/toolchanger-homing.cfg
@@ -162,7 +162,7 @@ gcode:
     {% endif %}
     {% if params.MESH is defined %}
       _REMOVE_Z_HOME_FOR_TOOL_OFFSET
-      #{% set applied = probe_compensation %}
+      {% set applied = probe_compensation %}
       {% if debug_output %}
         RESPOND TYPE=echo MSG='Bed Adjustment: {raise} = {raise + applied}'
       {% endif %}


### PR DESCRIPTION
This commented line seems to interfere with BED_MESH_CALIBRATE. With probe compensation applied, BED_MESH_CALIBRATE works for me (using T0).

The line was commented out in the commit below, although it seems unrelated to the main changes.

https://github.com/DraftShift/klipper-toolchanger/commit/bc0ba73bbf3868efc67acdbad1c79e5dc080f0da