### PR TITLE
calibrate offsets

### DIFF
--- a/macros/calibrate-offsets-macros.cfg
+++ b/macros/calibrate-offsets-macros.cfg
@@ -29,7 +29,7 @@ gcode:
     {% endif %}
     M104 S0
     {% for tool in tools[1:] %}
-        {% if params.TOOL is not defined or params.TOOL == tool %}
+        {% if params.TOOL is not defined or params.TOOL|int == tool %}
             SELECT_TOOL T={tool}  RESTORE_AXIS=Z
             STOP_TOOL_PROBE_CRASH_DETECTION
             {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}

--- a/macros/calibrate-offsets-macros.cfg
+++ b/macros/calibrate-offsets-macros.cfg
@@ -9,7 +9,7 @@ gcode:
     G0 X{printer["gcode_macro _CALIBRATION_SWITCH"].x} Y{printer["gcode_macro _CALIBRATION_SWITCH"].y} F10000
 
 
-[gcode_macro CALIBRATE_OFFSETS]
+[gcode_macro CALIBRATE_ALL_OFFSETS]
 description: Calibrate and save nozzle offsets
   TOOL= Tool number, optional (all tools are calibrated when omitted).
 gcode:
@@ -50,6 +50,11 @@ gcode:
     # Finish up
     SELECT_TOOL T={tools[0]} RESTORE_AXIS=XYZ
 
+[gcode_macro CALIBRATE_ONE_OFFSET]
+description: Calibrate and save nozzle offset for one tool
+  TOOL= Tool number
+gcode:
+   CALIBRATE_ALL_OFFSETS TOOL={params.TOOL}
 
 [gcode_macro CALIBRATE_NOZZLE_PROBE_OFFSET]
 gcode:

--- a/macros/calibrate-offsets-macros.cfg
+++ b/macros/calibrate-offsets-macros.cfg
@@ -8,7 +8,10 @@ gcode:
     G0 Z{printer["gcode_macro _CALIBRATION_SWITCH"].z} F10000
     G0 X{printer["gcode_macro _CALIBRATION_SWITCH"].x} Y{printer["gcode_macro _CALIBRATION_SWITCH"].y} F10000
 
-[gcode_macro CALIBRATE_ALL_OFFSETS]
+
+[gcode_macro CALIBRATE_OFFSETS]
+description: Calibrate and save nozzle offsets
+  TOOL= Tool number, optional (all tools are calibrated when omitted).
 gcode:
     {% set tools = printer.toolchanger.tool_numbers %}
     {% set names = printer.toolchanger.tool_names %}
@@ -18,63 +21,41 @@ gcode:
     {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
         _TOOLCHANGER_CLEAN_NOZZLE
     {% endif %}
-    _CALIBRATE_MOVE_OVER_PROBE    
+    _CALIBRATE_MOVE_OVER_PROBE
     M109 S150
     TOOL_LOCATE_SENSOR
-    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+    {% if params.TOOL is not defined or params.TOOL|int == 0 %}
+        TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe {names[0]|replace('tool ', '')|trim}"
+    {% endif %}
     M104 S0
     {% for tool in tools[1:] %}
-        SELECT_TOOL T={tool}  RESTORE_AXIS=Z
-        STOP_TOOL_PROBE_CRASH_DETECTION
-        {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
-            _TOOLCHANGER_CLEAN_NOZZLE
+        {% if params.TOOL is not defined or params.TOOL == tool %}
+            SELECT_TOOL T={tool}  RESTORE_AXIS=Z
+            STOP_TOOL_PROBE_CRASH_DETECTION
+            {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
+                _TOOLCHANGER_CLEAN_NOZZLE
+            {% endif %}
+            M104 T{tool} S150
+            _CALIBRATE_MOVE_OVER_PROBE
+            M109 T{tool} S150
+            TOOL_CALIBRATE_TOOL_OFFSET
+            TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
+            TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
+            TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
+            TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe {names[loop.index]|replace('tool ', '')|trim}"
+            M104 S0
         {% endif %}
-        M104 T{tool} S150
-        _CALIBRATE_MOVE_OVER_PROBE
-        M109 T{tool} S150
-        TOOL_CALIBRATE_TOOL_OFFSET
-        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_x_offset VALUE="{% raw %}{x:0.6f}{% endraw %}"
-        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_y_offset VALUE="{% raw %}{y:0.6f}{% endraw %}"
-        TOOL_CALIBRATE_SAVE_TOOL_OFFSET SECTION="{names[loop.index]}" ATTRIBUTE=gcode_z_offset VALUE="{% raw %}{z:0.6f}{% endraw %}"
-        TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{tool}"
-        M104 S0
     {% endfor %}
     
     # Finish up
     SELECT_TOOL T={tools[0]} RESTORE_AXIS=XYZ
 
 
-[gcode_macro CALIBRATE_ONE_OFFSET]
-gcode:
-    {% set tools = printer.toolchanger.tool_numbers %}
-    {% set names = printer.toolchanger.tool_names %}
-    # Tool 0
-    SELECT_TOOL T=0  RESTORE_AXIS=XYZ
-    STOP_TOOL_PROBE_CRASH_DETECTION
-    {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
-        _TOOLCHANGER_CLEAN_NOZZLE
-    {% endif %}
-    _CALIBRATE_MOVE_OVER_PROBE    
-    M104 S150
-    TOOL_LOCATE_SENSOR
-    M104 S0
-    SELECT_TOOL T={params.TOOL}  RESTORE_AXIS=Z
-    STOP_TOOL_PROBE_CRASH_DETECTION
-    {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
-        _TOOLCHANGER_CLEAN_NOZZLE
-    {% endif %}
-    M104 S150 T{params.TOOL}
-    _CALIBRATE_MOVE_OVER_PROBE    
-    TOOL_CALIBRATE_TOOL_OFFSET
-    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T{params.TOOL}"
-    M104 S0
-    
-    # Finish up
-    SELECT_TOOL T=0 RESTORE_AXIS=XYZ
-
-
 [gcode_macro CALIBRATE_NOZZLE_PROBE_OFFSET]
 gcode:
+    {% set active_tool_number = printer.tool_probe_endstop.active_tool_number %}
+    {% set names = printer.toolchanger.tool_names %}
+    
     STOP_TOOL_PROBE_CRASH_DETECTION
     {% if printer["gcode_macro _TOOLCHANGER_CLEAN_NOZZLE"] is defined %}
         _TOOLCHANGER_CLEAN_NOZZLE
@@ -82,5 +63,5 @@ gcode:
     _CALIBRATE_MOVE_OVER_PROBE
     M109 S150
     TOOL_LOCATE_SENSOR
-    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe T0"
+    TOOL_CALIBRATE_PROBE_OFFSET PROBE="tool_probe {names[active_tool_number]|replace('tool ', '')|trim}"
     M104 S0


### PR DESCRIPTION
Remove code duplication and refactor the calibration for both single-tool and multi-tool setups into a single macro.

Ensure that the G-code offsets are saved under the correct tool names (e.g. [tool AVR1] instead of [tool T1]).